### PR TITLE
Hotfix - column order in APM analysis

### DIFF
--- a/backend/extractionSteps/JobStepBase.py
+++ b/backend/extractionSteps/JobStepBase.py
@@ -52,7 +52,6 @@ class JobStepBase(ABC):
         headers = ["controller", "application", "applicationId"] + (["description"] if self.componentType == "apm" else []) + list(rawDataHeaders)
 
         writeUncoloredRow(rawDataSheet, 1, headers)
-        rawDataSheet.column_dimensions["C"].hidden = True
 
         # Write Data
         rowIdx = 2

--- a/backend/output/reports/AgentMatrixReport.py
+++ b/backend/output/reports/AgentMatrixReport.py
@@ -23,7 +23,6 @@ class AgentMatrixReport(ReportBase):
         logging.debug(f"Creating workbook sheet for App Agents")
         appAgentsSheet = workbook.create_sheet(f"Overall - App Agents")
         writeUncoloredRow(appAgentsSheet, 1, ["controller", "application", "applicationId", *allAppAgentVersions])
-        appAgentsSheet.column_dimensions["C"].hidden = True
 
         # Write Data
         rowIdx = 2
@@ -65,7 +64,6 @@ class AgentMatrixReport(ReportBase):
             1,
             ["controller", "application", "applicationId", *allMachineAgentVersions],
         )
-        machineAgentsSheet.column_dimensions["C"].hidden = True
 
         # Write Data
         rowIdx = 2

--- a/backend/output/reports/CustomMetricsReport.py
+++ b/backend/output/reports/CustomMetricsReport.py
@@ -34,8 +34,6 @@ class CustomMetricsReport(ReportBase):
             ],
         )
 
-        summarySheet.column_dimensions["D"].hidden = True
-
         rowIdx = 2
         for host, hostInfo in controllerData.items():
             for component in hostInfo["apm"].values():

--- a/backend/output/reports/MaturityAssessmentReport.py
+++ b/backend/output/reports/MaturityAssessmentReport.py
@@ -43,7 +43,6 @@ class MaturityAssessmentReport(ReportBase):
                 1,
                 data_header
             )
-            analysisSheet.column_dimensions["D"].hidden = True
 
             rowIdx = 2
             for host, hostInfo in controllerData.items():

--- a/backend/output/reports/SyntheticsReport.py
+++ b/backend/output/reports/SyntheticsReport.py
@@ -96,8 +96,6 @@ class SyntheticsReport(ReportBase):
             )
             rowIdx += 1
 
-        summarySheet.column_dimensions["D"].hidden = True
-
         addFilterAndFreeze(summarySheet, freezePane="F2")
         resizeColumnWidth(summarySheet)
 


### PR DESCRIPTION
Fixes column order in APM analysis and unhide applicationId column in every report.