### PR TITLE
fix(#193): handle list API responses gracefully in getServers and HealthRulesAndAlerting

### DIFF
--- a/backend/api/appd/AppDService.py
+++ b/backend/api/appd/AppDService.py
@@ -871,8 +871,13 @@ class AppDService:
         for serverResult, serverAvailabilityResult in zip(serversResults,
                                                           serversAvailabilityResults):
             machine = serverResult.data
-            value = get_recursively(serverAvailabilityResult.data["data"],
-                                    "value")
+            availabilityData = serverAvailabilityResult.data
+            if isinstance(availabilityData, dict) and "data" in availabilityData:
+                value = get_recursively(availabilityData["data"], "value")
+            else:
+                logging.warning(f"Unexpected server availability response for machineId '{machine.get('hostId', '?')}' "
+                                f"(error={serverAvailabilityResult.error}, type={type(availabilityData).__name__}); defaulting availability to 0")
+                value = None
             if value:
                 availability = next(iter(value))
                 machine["availability"] = availability

--- a/backend/extractionSteps/maturityAssessment/apm/HealthRulesAndAlertingAPM.py
+++ b/backend/extractionSteps/maturityAssessment/apm/HealthRulesAndAlertingAPM.py
@@ -50,7 +50,11 @@ class HealthRulesAndAlertingAPM(JobStepBase):
             for idx, applicationName in enumerate(hostInfo[self.componentType]):
                 application = hostInfo[self.componentType][applicationName]
 
-                application["eventCounts"] = eventCounts[idx].data
+                if eventCounts[idx].error is not None or not isinstance(eventCounts[idx].data, dict):
+                    logger.warning(f"Failed to retrieve event counts for '{applicationName}': {eventCounts[idx].error}; defaulting to zero violations.")
+                    application["eventCounts"] = {"policyViolationEventCounts": {"totalPolicyViolations": {"warning": 0, "critical": 0}}}
+                else:
+                    application["eventCounts"] = eventCounts[idx].data
                 application["policies"] = policies[idx].data
 
                 trimmedHrs = [healthRule for healthRule in healthRules[idx].data if healthRule.error is None]

--- a/backend/extractionSteps/maturityAssessment/brum/HealthRulesAndAlertingBRUM.py
+++ b/backend/extractionSteps/maturityAssessment/brum/HealthRulesAndAlertingBRUM.py
@@ -50,7 +50,11 @@ class HealthRulesAndAlertingBRUM(JobStepBase):
             for idx, applicationName in enumerate(hostInfo[self.componentType]):
                 application = hostInfo[self.componentType][applicationName]
 
-                application["eventCounts"] = eventCounts[idx].data
+                if eventCounts[idx].error is not None or not isinstance(eventCounts[idx].data, dict):
+                    logger.warning(f"Failed to retrieve event counts for '{applicationName}': {eventCounts[idx].error}; defaulting to zero violations.")
+                    application["eventCounts"] = {"policyViolationEventCounts": {"totalPolicyViolations": {"warning": 0, "critical": 0}}}
+                else:
+                    application["eventCounts"] = eventCounts[idx].data
                 application["policies"] = policies[idx].data
 
                 trimmedHrs = [healthRule for healthRule in healthRules[idx].data if healthRule.error is None]

--- a/backend/extractionSteps/maturityAssessment/mrum/HealthRulesAndAlertingMRUM.py
+++ b/backend/extractionSteps/maturityAssessment/mrum/HealthRulesAndAlertingMRUM.py
@@ -50,7 +50,11 @@ class HealthRulesAndAlertingMRUM(JobStepBase):
             for idx, applicationName in enumerate(hostInfo[self.componentType]):
                 application = hostInfo[self.componentType][applicationName]
 
-                application["eventCounts"] = eventCounts[idx].data
+                if eventCounts[idx].error is not None or not isinstance(eventCounts[idx].data, dict):
+                    logger.warning(f"Failed to retrieve event counts for '{applicationName}': {eventCounts[idx].error}; defaulting to zero violations.")
+                    application["eventCounts"] = {"policyViolationEventCounts": {"totalPolicyViolations": {"warning": 0, "critical": 0}}}
+                else:
+                    application["eventCounts"] = eventCounts[idx].data
                 application["policies"] = policies[idx].data
 
                 trimmedHrs = [healthRule for healthRule in healthRules[idx].data if healthRule.error is None]


### PR DESCRIPTION
## Summary
Fixes #193
When the AppDynamics API returns a **list** instead of the expected **dict** for `getEventCounts` (APM/BRUM/MRUM) or `getServerAvailability`, the tool crashed with a fatal `TypeError` that aborted the entire job.
## Changes
- **`AppDService.getServers`** — Guard `serverAvailabilityResult.data` with an `isinstance(dict)` check before key access; default availability to `None` with a warning log.
- **`HealthRulesAndAlertingAPM/BRUM/MRUM` `extract()`** — Guard `eventCounts[idx].data` with an error/type check; default to zero violations so `analyze()` can proceed safely.
## Behaviour after fix
- No job abort on malformed API responses.
- A `WARNING` log entry is emitted for each affected application/machine.
- Affected applications report `0` health rule violations rather than crashing.