### PR TITLE
fix: handle list API responses for controller 26.7+ compatibility (v1.8.2)

### DIFF
--- a/input/thresholds/DefaultThresholds.json
+++ b/input/thresholds/DefaultThresholds.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"apm": {
 		"AppAgentsAPM": {
 			"platinum": {


### PR DESCRIPTION
## Summary
Fixes #193 and adds compatibility for controller 26.7+.

This PR incorporates two fixes for AppDynamics controller API response format changes where endpoints now return a plain list instead of the expected `{"data": [...]}` dict, causing a fatal `TypeError` that aborted the entire job.

## Changes

**From #194 (fix #193):**
- `AppDService.getServers` — guard `serverAvailabilityResult.data` with `isinstance(dict)` check; default availability to `None` with a warning log
- `HealthRulesAndAlertingAPM/BRUM/MRUM` — guard `eventCounts[idx].data` with error/type check; default to zero violations so `analyze()` proceeds

**New (controller 26.7+):**
- `AppDService.getAppServerAgentsIds` — `POST /controller/restui/agents/list/appserver/ids` now returns a plain list on 26.7+; guard with `isinstance` check to support both old and new formats

- `DefaultThresholds.json` — version bumped to `1.8.2` to match tool version

## Compatibility
- Fully backward compatible with all controller versions prior to 26.7
- Required for controllers upgraded to 26.7+